### PR TITLE
Re-added Code Climate ratings

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,3 +2,6 @@ engines:
   eslint:
     enabled: true
     channel: "eslint-2"
+ratings:
+ paths:
+   - "**.js"


### PR DESCRIPTION
When adding a custom Code Climate configuration rating paths must be specified manually, otherwise all files will be omitted.
